### PR TITLE
fix(dataloader): fix bug where the watch handler fires off even though the ajax requests hasnt returned

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -54,34 +54,36 @@ rprtr.controller('SectionCtrl', ['$scope', 'anythingToRelative', function($scope
 
 
 rprtr.controller('HomeCtrl', ['$scope', '$filter', function($scope, $filter) {
-  $scope.$watch('loading', function(){
-    if($scope.uniqueDeclarations) $scope.refactoringPotential = parseInt((1 - ($scope.uniqueDeclarations.length / $scope.declarations.length)) * 100);
-    if ($scope.selectors) {
-      if($scope.selectors.length > 4095) {
-        $scope.selectorsWarning = 'IE9 and lower only allows for 4095 selectors per stylesheet. This is over the limit by: ' + parseInt($scope.selectors.length - 4095);
-      } else if($scope.selectors.length < 4095) {
-        $scope.selectorsWarning = 'Currently '+ parseInt(4095 - $scope.selectors.length) + ' under the limit.';
+  $scope.$watch('loading', function(isLoading) {
+    if (!isLoading) {
+      if($scope.uniqueDeclarations) $scope.refactoringPotential = parseInt((1 - ($scope.uniqueDeclarations.length / $scope.declarations.length)) * 100);
+      if ($scope.selectors) {
+        if($scope.selectors.length > 4095) {
+          $scope.selectorsWarning = 'IE9 and lower only allows for 4095 selectors per stylesheet. This is over the limit by: ' + parseInt($scope.selectors.length - 4095);
+        } else if($scope.selectors.length < 4095) {
+          $scope.selectorsWarning = 'Currently '+ parseInt(4095 - $scope.selectors.length) + ' under the limit.';
+        }
       }
+      if($scope.fontSizes) {
+        if($scope.fontSizes.length > 128) {
+          $scope.fontSizesWarning = 'You have over 128 font-size declarations, u r silly.';
+        } else if($scope.fontSizes.length > 512) {
+          $scope.fontSizesWarning = 'Over 512 font-size declarations? Go home. You are drunk.';
+        };
+      };
+      if($scope.uniqueFontSizes){
+        if($scope.uniqueFontSizes.length > 64) {
+          $scope.uniqueFontSizesWarning = 'You have over 64 unique font sizes. Type scale much?';
+        } else if ($scope.uniqueFontSizes.length > 128) {
+          $scope.uniqueFontSizesWarning = 'Over 128 unique font sizes. Alright, you\'ve lost your computer privileges.';
+        };
+      };
+      if($scope.declarations){
+        if($scope.declarations.length > 4095) {
+          $scope.declarationsWarning = 'You have ' + $scope.declarations.length + ' selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Also, that is a lot.'
+        };
+      };
     }
-    if($scope.fontSizes) {
-      if($scope.fontSizes.length > 128) {
-        $scope.fontSizesWarning = 'You have over 128 font-size declarations, u r silly.';
-      } else if($scope.fontSizes.length > 512) {
-        $scope.fontSizesWarning = 'Over 512 font-size declarations? Go home. You are drunk.';
-      };
-    };
-    if($scope.uniqueFontSizes){
-      if($scope.uniqueFontSizes.length > 64) {
-        $scope.uniqueFontSizesWarning = 'You have over 64 unique font sizes. Type scale much?';
-      } else if ($scope.uniqueFontSizes.length > 128) {
-        $scope.uniqueFontSizesWarning = 'Over 128 unique font sizes. Alright, you\'ve lost your computer privileges.';
-      };
-    };
-    if($scope.declarations){
-      if($scope.declarations.length > 4095) {
-        $scope.declarationsWarning = 'You have ' + $scope.declarations.length + ' selectors. Internet Explorer supports a maximum of 4095 selectors per stylesheet. Also, that is a lot.'
-      };
-    };
   });
 
 }]);

--- a/js/services.js
+++ b/js/services.js
@@ -162,26 +162,26 @@ rprtr.factory('anythingToRelative', function(){
 
 
 // Service to load all data
-rprtr.factory('dataloader', function($http, selectors, declarationsByType, createUniques, anythingToRelative){
+rprtr.factory('dataloader', function($http, selectors, declarationsByType, createUniques, anythingToRelative, $q){
   return function($scope) {
     var styleData = $scope.styleData;
     // Set data var
       $scope.loading = true;
-      $http.get('data/' + styleData + '/rules.json').success(function(res) {
+      var rules = $http.get('data/' + styleData + '/rules.json').success(function(res) {
         $scope.styles = res;
         selectors($scope);
       });
-      $http.get('data/' + styleData + '/declarations.json').success(function(res){
+      var declarations = $http.get('data/' + styleData + '/declarations.json').success(function(res){
         $scope.declarations = res;
         // Create arrays for each declaration type in the factory
         declarationsByType($scope);
       });
-      $http.get('data/' + styleData + '/unique_declarations.json').success(function(res){
+      var uniqueDeclarations = $http.get('data/' + styleData + '/unique_declarations.json').success(function(res){
         $scope.uniqueDeclarations = res;
       });
-      $scope.$watch('selectors', function(){
-        // Wait for selectors to load, then get uniques
-        if($scope.selectors) {
+
+      $q.all([rules, declarations, uniqueDeclarations]).then(function() {
+        $scope.$watch('selectors', function(){
           createUniques($scope);
 
           anythingToRelative($scope.margins);
@@ -189,10 +189,9 @@ rprtr.factory('dataloader', function($http, selectors, declarationsByType, creat
           anythingToRelative($scope.widths);
           anythingToRelative($scope.heights);
 
-          // may not be truly finished yet
           $scope.loading = false;
-        };
-      });
+        });
+      }, function(error) { console.log(error); });
   };
 });
 


### PR DESCRIPTION
we need to wait for the requests to return before trying to parse the selectors and we also don't try and do any work in the controllers that work on the data when the loading flag is still `true`

this error was replicated locally and on http://mrmrs.github.io/rprtr (it was consistent whenever i tried to load the new york times)
- localhost
  ![screen shot 2013-11-08 at 10 09 47 pm](https://f.cloud.github.com/assets/354746/1506068/2f162e3c-4909-11e3-95a6-de804fad358d.png)
- http://mrmrs.github.io/rprtr
  ![screen shot 2013-11-09 at 12 36 34 am](https://f.cloud.github.com/assets/354746/1506277/1be63f12-491a-11e3-9182-994f3621b15e.png)
