### PR TITLE
added option for request to handle untrusted SSL certificates

### DIFF
--- a/src/routes/routes.coffee
+++ b/src/routes/routes.coffee
@@ -82,7 +82,7 @@ util =
 
   getUrlContents: (url) ->
     _when.promise (resolve, reject, notify) ->
-      req = request url: url, encoding: 'utf8', (error, response, body) ->
+      req = request url: url, encoding: 'utf8', rejectUnauthorized: false, (error, response, body) ->
         if not error and response.statusCode is 200
           resolve body
         else


### PR DESCRIPTION
Hello,
really great job! Simply love it.

There was an 'issue' when dealing with CSS from untrusted sources (like 'cheap' HTTPS certificates).
One line enabled to check the CSS of my site https://christian.fei.ninja/
