### PR TITLE
Add defaults to express-session

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, 'public')));
 
 var secret = Math.random().toString(36).slice(2);
-app.use(session({ secret: secret }));
+app.use(session({ secret: secret, saveUninitialized: true, resave: true }));
 
 app.use('/', routes);
 app.use('/stats', stats);


### PR DESCRIPTION
This removes the following deprecation messages:

```
express-session deprecated undefined resave option; provide resave option main.js:43:9
express-session deprecated undefined saveUninitialized option; provide saveUninitialized option main.js:43:9
```

Relevant documentation: https://github.com/expressjs/session#options
