### PR TITLE
Move 'http(s)' check.

### DIFF
--- a/routes/parse.js
+++ b/routes/parse.js
@@ -12,6 +12,7 @@ router.post('/', function(req, res) {
   form.parse(req, function(error, fields, files) {
     var url = fields.url;
     req.session.css = null;
+    if (!url.match(/^(http|https)/g)) url = 'http://'+url;
     if (fields.css) {
       req.session.css = fields.css;
       res.redirect('/stats');
@@ -19,8 +20,6 @@ router.post('/', function(req, res) {
       console.log(files.file);
     } else if (url.match(/\.css/g)) {
       res.redirect('/stats?link=' + encodeURIComponent(url));
-    } else if (!url.match(/^(http|https)/g)) {
-      res.redirect('/stats?url=' + encodeURIComponent('http://' + url));
     } else {
       console.log('no match');
       res.redirect('/stats?url=' + encodeURIComponent(url));


### PR DESCRIPTION
Before I was getting this error when I had the input `ryanjacobs.io/css/style.css`:
![error message](https://cloud.githubusercontent.com/assets/4251257/5565390/6ff5fc12-8ead-11e4-89e7-43a934c5b205.png)

But now I moved the http/https check to before we run `encodeURIComponent` and it works just fine. :smile:

