### PR TITLE
Count resets of margin and padding

### DIFF
--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -152,6 +152,12 @@ function rulesizeGraph(rules) {
   return array;
 }
 
+function propertyResets(stats, property) {
+  return stats.declarations.byProperty[property].filter(function(declaration) {
+    return declaration.value.match(/^(0\w* ?)+$/);
+  }).length;
+}
+
 module.exports = function(obj) {
 
   var model = obj;
@@ -168,6 +174,11 @@ module.exports = function(obj) {
   model.rulesizeGraph = rulesizeGraph(model.stats.rules);
 
   model.uniquesGraph = uniquesGraph(model.stats);
+
+  model.propertyResets = {
+    margin: propertyResets(model.stats, 'margin'),
+    padding: propertyResets(model.stats, 'padding')
+  };
 
   return model;
 

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -45,6 +45,20 @@
   </div>
 </section>
 
+<section id="resets" class="mb4">
+  <h1 class="h2 m0">Total Resets</h1>
+  <div class="flex flex-wrap mxn2">
+    <div class="col-6 sm-col-4 lg-col-2 p2">
+      <p class="bold lh1 m0">Margin</p>
+      <h1 class="h0 lh1 m0">{{number propertyResets.margin }}</h1>
+    </div>
+    <div class="col-6 sm-col-4 lg-col-2 p2">
+      <p class="bold lh1 m0">Padding</p>
+      <h1 class="h0 lh1 m0">{{number propertyResets.padding }}</h3>
+    </div>
+  </div>
+</section>
+
 <section id="declarations" class="mb4">
   <h1 class="h2 m0">Total Declarations</h1>
   <div class="flex flex-wrap mxn2">


### PR DESCRIPTION
Fixes Issues #146 and #147.

Not sure if it is at the right place in the view. Or would this be better under "Total Declarations"?

Im using this regex to detect if the value is set to 0: `^(0\w* ?)+$`
This matches (same for padding):
* margin: 0;
* margin: 0 0 0 0;
* margin: 0px;
* margin: 0 0px;