### PR TITLE
Fixed Raw-CSS-Feature. #154

### DIFF
--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -157,9 +157,7 @@ module.exports = function(obj) {
   var model = obj;
   model.cssPretty = beautify(obj.css);
 
-  model.stats = cssstats(obj.css, {
-    safe: true
-  });
+  model.stats = cssstats(obj.css, { safe: true });
   if (!model.stats) {
     console.log('no stats');
   }

--- a/routes/parse.js
+++ b/routes/parse.js
@@ -1,4 +1,3 @@
-
 var express = require('express');
 var formidable = require('formidable');
 var normalizeUrl = require('normalize-url');
@@ -12,13 +11,19 @@ router.get('/', function(req, res) {
 
 router.post('/', function(req, res) {
   var form = new formidable.IncomingForm();
-  form.parse(req, function(error, fields, files) {
-    var url = normalizeUrl(fields.url);
+  form.parse(req, function(error, fields) {
+    if (fields.url) {
+      var url = normalizeUrl(fields.url);
 
-    if (isCss(url)) {
-      res.redirect('/stats?link=' + encodeURIComponent(url));
+      if (isCss(url)) {
+        res.redirect('/stats?link=' + encodeURIComponent(url));
+      } else {
+        res.redirect('/stats?url=' + encodeURIComponent(url));
+      }
     } else {
-      res.redirect('/stats?url=' + encodeURIComponent(url));
+      // Raw CSS was given
+      req.session.css = fields.css;
+      res.redirect('/stats');
     }
   });
 });

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -1,4 +1,3 @@
-
 var express = require('express');
 var router = express.Router();
 

--- a/services/resource.js
+++ b/services/resource.js
@@ -1,13 +1,9 @@
-
 var request = require('request');
 var q = require('q');
-
 var getCss = require('get-css');
 
 module.exports = {
-
   getCssFromLink: function(link) {
-
     var deferred = q.defer();
 
     request({ url: link, timeout: 5000 }, function(error, response, body) {
@@ -19,24 +15,10 @@ module.exports = {
     });
 
     return deferred.promise;
-
   },
 
   getCssFromUrl: function(url) {
-
-    var deferred = q.defer();
-
-    getCss(url)
-      .then(function(response) {
-        deferred.resolve(response);
-      })
-      .catch(function(error) {
-        deferred.reject(error);
-      });
-
-    return deferred.promise;
-
+    return getCss(url);
   }
-
 };
 


### PR DESCRIPTION
The `/parse` route always tried to use the URL-Parameter of the form. But in case no URL is given, try to use the data from the CSS-Parameter, save it into the session and redirect to `/stats`.

Also removed some unnecessary code from `getCssFromUrl` function in `resource.js` as `getCss` already returns a Promise.