### PR TITLE
Update cssstats-core to 2.x

### DIFF
--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -137,24 +137,25 @@ function parsePropertiesBreakdown(stats) {
 function uniquesGraph(stats) {
   var obj = {};
   obj.max = 0;
-  var keys = ['margin', 'padding', 'width', 'height', 'color', 'backgroundColor', 'float', 'display', 'position'];
+  var keys = ['width', 'height', 'margin', 'padding', 'color', 'background-color'];
   keys.forEach(function(key) {
-    obj[key] = {};
-    if (!stats.declarations.byProperty[key]) {
-      obj[key].total = 0;
-      obj[key].unique = 0;
+    camelKey = camelCase(key);
+    obj[camelKey] = {};
+    if (!stats.declarations.properties[key]) {
+      obj[camelKey].total = 0;
+      obj[camelKey].unique = 0;
     } else {
-      obj[key].total = stats.declarations.byProperty[key].length;
-      obj[key].unique = stats.declarations.unique[key].length;
-      if (obj[key].total > obj.max) {
-        obj.max = obj[key].total;
+      obj[camelKey].total = stats.declarations.properties[key].length;
+      obj[camelKey].unique = stats.declarations.getUniquePropertyCount(key);
+      if (obj[camelKey].total > obj.max) {
+        obj.max = obj[camelKey].total;
       }
     }
   });
   keys.forEach(function(key) {
-    if (!obj[key]) return false;
-    obj[key].percentTotal = obj[key].total / obj.max;
-    obj[key].percentUnique = obj[key].unique / obj.max;
+    if (!obj[camelKey]) return false;
+    obj[camelKey].percentTotal = obj[camelKey].total / obj.max;
+    obj[camelKey].percentUnique = obj[camelKey].unique / obj.max;
   });
   return obj;
 }
@@ -182,10 +183,10 @@ module.exports = function(obj) {
 
   model.totals = parseTotals(model.stats);
   model.uniques = parseUniques(model.stats);
+  model.uniquesGraph = uniquesGraph(model.stats);
   //model.specificityGraph = parseSpecificity(model.stats.selectors);
   //model.rulesizeGraph = rulesizeGraph(model.stats.rules);
 
-  //model.uniquesGraph = uniquesGraph(model.stats);
 
   return model;
 

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -33,17 +33,9 @@ function parseUniques(stats) {
     uniques[camelCase(property)] = _.uniq(stats.declarations.properties[property]);
   }
 
-  //uniques.fontSize = stats.declarations.unique.fontSize;
-  //uniques.fontFamily = stats.declarations.unique.fontFamily;
-  //uniques.width = stats.declarations.unique.width;
-  //uniques.height = stats.declarations.unique.height;
-  //uniques.color = stats.declarations.unique.color;
-  //uniques.backgroundColor = stats.declarations.unique.backgroundColor;
-  //uniques.margin = stats.declarations.unique.margin;
-  //uniques.padding = stats.declarations.unique.padding;
-  //uniques.borderRadius = stats.declarations.unique.borderRadius;
-
-  //uniques.fontSizeSorted = sortFontSizes(stats);
+  uniques.fontSize = _.uniq(stats.declarations.getAllFontSizes());
+  uniques.fontFamily = _.uniq(stats.declarations.getAllFontFamilies());
+  uniques.fontSizeSorted = sortFontSizes(uniques.fontSize);
 
   return uniques;
 
@@ -101,17 +93,17 @@ function fontSizeToPx(value) {
   }
 }
 
-function sortFontSizes(stats) {
+function sortFontSizes(fontSizes) {
   var sortBy = function(a, b) {
-    c = fontSizeToPx(a.value);
-    d = fontSizeToPx(b.value);
+    c = fontSizeToPx(a);
+    d = fontSizeToPx(b);
     if (c > d) {
       return -1;
     } else {
       return 1;
     }
   }
-  var sorted = stats.declarations.unique.fontSize;
+  var sorted = fontSizes;
   if (!sorted) return false;
   return sorted.sort(sortBy);
 }

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -1,7 +1,26 @@
 
 var cssstats = require('cssstats');
 var beautify = require('cssbeautify');
+var camelCase = require('camel-case')
+var _ = require('lodash');
 
+
+function parseTotals(stats) {
+
+  if (!stats) return false;
+
+  stats.declarations.properties.total = _.size(stats.declarations.properties);
+
+  var totals = {};
+  var totalProperties = ['float', 'width', 'height', 'color', 'background-color'];
+  for(var property of totalProperties) {
+    totals[camelCase(property)] = stats.declarations.properties[property].length;
+  }
+
+  totals.fontSize = stats.declarations.getAllFontSizes().length;
+
+  return totals;
+}
 
 function parseUniques(stats) {
 
@@ -163,11 +182,13 @@ module.exports = function(obj) {
   if (!model.stats) {
     console.log('no stats');
   }
-  model.uniques = parseUniques(model.stats);
-  model.specificityGraph = parseSpecificity(model.stats.selectors);
-  model.rulesizeGraph = rulesizeGraph(model.stats.rules);
 
-  model.uniquesGraph = uniquesGraph(model.stats);
+  model.totals = parseTotals(model.stats);
+  //model.uniques = parseUniques(model.stats);
+  //model.specificityGraph = parseSpecificity(model.stats.selectors);
+  //model.rulesizeGraph = rulesizeGraph(model.stats.rules);
+
+  //model.uniquesGraph = uniquesGraph(model.stats);
 
   return model;
 

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -186,6 +186,7 @@ module.exports = function(obj) {
   model.uniquesGraph = uniquesGraph(model.stats);
   model.specificityGraph = model.stats.selectors.getSpecificityGraph();
   model.rulesizeGraph = model.stats.rules.size.graph;
+  model.mediaQueries = _.uniq(model.stats.mediaQueries.values);
 
   return model;
 

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -184,9 +184,8 @@ module.exports = function(obj) {
   model.totals = parseTotals(model.stats);
   model.uniques = parseUniques(model.stats);
   model.uniquesGraph = uniquesGraph(model.stats);
-  //model.specificityGraph = parseSpecificity(model.stats.selectors);
-  //model.rulesizeGraph = rulesizeGraph(model.stats.rules);
-
+  model.specificityGraph = model.stats.selectors.getSpecificityGraph();
+  model.rulesizeGraph = model.stats.rules.size.graph;
 
   return model;
 

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -27,18 +27,23 @@ function parseUniques(stats) {
   if (!stats) return false;
 
   var uniques = {};
+  var uniqueProperties = ['width', 'height', 'color', 'background-color',
+    'margin', 'padding', 'border-radius'];
+  for(var property of uniqueProperties) {
+    uniques[camelCase(property)] = _.uniq(stats.declarations.properties[property]);
+  }
 
-  uniques.fontSize = stats.declarations.unique.fontSize;
-  uniques.fontFamily = stats.declarations.unique.fontFamily;
-  uniques.width = stats.declarations.unique.width;
-  uniques.height = stats.declarations.unique.height;
-  uniques.color = stats.declarations.unique.color;
-  uniques.backgroundColor = stats.declarations.unique.backgroundColor;
-  uniques.margin = stats.declarations.unique.margin;
-  uniques.padding = stats.declarations.unique.padding;
-  uniques.borderRadius = stats.declarations.unique.borderRadius;
+  //uniques.fontSize = stats.declarations.unique.fontSize;
+  //uniques.fontFamily = stats.declarations.unique.fontFamily;
+  //uniques.width = stats.declarations.unique.width;
+  //uniques.height = stats.declarations.unique.height;
+  //uniques.color = stats.declarations.unique.color;
+  //uniques.backgroundColor = stats.declarations.unique.backgroundColor;
+  //uniques.margin = stats.declarations.unique.margin;
+  //uniques.padding = stats.declarations.unique.padding;
+  //uniques.borderRadius = stats.declarations.unique.borderRadius;
 
-  uniques.fontSizeSorted = sortFontSizes(stats);
+  //uniques.fontSizeSorted = sortFontSizes(stats);
 
   return uniques;
 
@@ -184,7 +189,7 @@ module.exports = function(obj) {
   }
 
   model.totals = parseTotals(model.stats);
-  //model.uniques = parseUniques(model.stats);
+  model.uniques = parseUniques(model.stats);
   //model.specificityGraph = parseSpecificity(model.stats.selectors);
   //model.rulesizeGraph = rulesizeGraph(model.stats.rules);
 

--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -108,32 +108,6 @@ function sortFontSizes(fontSizes) {
   return sorted.sort(sortBy);
 }
 
-function parsePropertiesBreakdown(stats) {
-  if (!stats) return false;
-  var result = [];
-  var total = stats.declarations.all.length;
-  var properties = stats.aggregates.properties;
-  var otherSum = 0;
-  if (!properties.length) return false;
-  properties.forEach(function(property) {
-    var obj = {};
-    obj.property = property;
-    obj.percentage = (stats.declarations.byProperty[property].length / total * 100);
-    if (obj.percentage < 2) {
-      otherSum += obj.percentage;
-    } else {
-      result.push(obj);
-    }
-  });
-  if (!result.length) return false;
-  result = result.sort(function(a,b) { return b.percentage - a.percentage });
-  result.push({ property: 'other', percentage: otherSum });
-  result.forEach(function(property) {
-    property.percentagePretty = property.percentage.toFixed(2);
-  });
-  return result;
-}
-
 function uniquesGraph(stats) {
   var obj = {};
   obj.max = 0;
@@ -158,15 +132,6 @@ function uniquesGraph(stats) {
     obj[camelKey].percentUnique = obj[camelKey].unique / obj.max;
   });
   return obj;
-}
-
-function rulesizeGraph(rules) {
-  var array = [];
-  rules.forEach(function(rule) {
-    if (!rule.declarations) return false;
-    array.push(rule.declarations.length);
-  });
-  return array;
 }
 
 module.exports = function(obj) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "body-parser": "~1.8.1",
+    "camel-case": "^1.2.2",
     "chartable": "0.0.1",
     "cheerio": "^0.18.0",
     "cookie-parser": "~1.3.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cheerio": "^0.18.0",
     "cookie-parser": "~1.3.3",
     "cssbeautify": "^0.3.1",
-    "cssstats": "1.2.1",
+    "cssstats": "^2.2.0",
     "debug": "~2.0.0",
     "express": "^4.10.2",
     "express-handlebars": "^1.1.0",

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -78,13 +78,13 @@
 <section id="unique-colors" class="mb4">
   <h2>
     {{ uniques.color.length }}
-    {{pluralize uniques.color.length 'Unique Color' 'Unique Colors' }}
+    {{ pluralize uniques.color.length 'Unique Color' 'Unique Colors' }}
   </h2>
   <div class="flex flex-wrap mxn2">
     {{#each uniques.color }}
       <div class="col-4 sm-col-3 lg-col-2 p2">
-        <div class="h0 lh1 bold" style="color:{{ this.value }}">Aa</div>
-        <div class="h6 break-word">{{ this.value }}</div>
+        <div class="h0 lh1 bold" style="color:{{ this }}">Aa</div>
+        <div class="h6 break-word">{{ this }}</div>
       </div>
     {{/each}}
   </div>
@@ -93,17 +93,17 @@
 <section id="unique-background-colors" class="mb4">
   <h2>
     {{ uniques.backgroundColor.length }}
-    {{pluralize uniques.backgroundColor.length 'Unique Background Color' 'Unique Background Colors' }}
+    {{ pluralize uniques.backgroundColor.length 'Unique Background Color' 'Unique Background Colors' }}
   </h2>
   <div class="flex flex-wrap mxn2">
     {{#each uniques.backgroundColor }}
       <div class="col-4 sm-col-3 lg-col-2 p2">
         <div class="mb1">
           <svg viewBox="0 0 64 64" width="64" height="64" style="display:block;width:100%;height:auto">
-            <rect width="64" height="64" fill="{{ this.value }}"/>
+            <rect width="64" height="64" fill="{{ this }}"/>
           </svg>
         </div>
-        <div class="h6 break-word">{{ this.value }}</div>
+        <div class="h6 break-word">{{ this }}</div>
       </div>
     {{/each}}
   </div>

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -28,19 +28,19 @@
 
 <section id="top-stats" class="flex flex-wrap mxn2 mb4">
   <div class="col-6 md-col-3 p2">
-    <h1 class="h00 lh1 m0">{{number stats.rules.length }}</h1>
+    <h1 class="h00 lh1 m0">{{number stats.rules.total }}</h1>
     <p class="h3 bold lh1 m0">Rules</p>
   </div>
   <div class="col-6 md-col-3 p2">
-    <h1 class="h00 lh1 m0">{{number stats.aggregates.selectors }}</h1>
+    <h1 class="h00 lh1 m0">{{number stats.selectors.total }}</h1>
     <p class="h3 bold lh1 m0">Selectors</p>
   </div>
   <div class="col-6 md-col-3 p2">
-    <h1 class="h00 lh1 m0">{{number stats.aggregates.declarations }}</h1>
+    <h1 class="h00 lh1 m0">{{number stats.declarations.total }}</h1>
     <p class="h3 bold lh1 m0">Declarations</p>
   </div>
   <div class="col-6 md-col-3 p2">
-    <h1 class="h00 lh1 m0">{{number stats.aggregates.properties.length }}</h1>
+    <h1 class="h00 lh1 m0">{{number stats.declarations.properties.total }}</h1>
     <p class="h3 bold lh1 m0">Properties</p>
   </div>
 </section>
@@ -50,27 +50,27 @@
   <div class="flex flex-wrap mxn2">
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Font Size</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.fontSize.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.fontSize }}</h1>
     </div>
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Float</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.float.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.float }}</h1>
     </div>
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Width</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.width.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.width }}</h1>
     </div>
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Height</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.height.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.height }}</h1>
     </div>
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Color</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.color.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.color }}</h1>
     </div>
     <div class="col-6 sm-col-4 lg-col-2 p2">
       <p class="bold lh1 m0">Background Color</p>
-      <h1 class="h0 lh1 m0">{{number stats.aggregates.backgroundColor.total }}</h1>
+      <h1 class="h0 lh1 m0">{{number totals.backgroundColor }}</h1>
     </div>
   </div>
 </section>
@@ -136,6 +136,7 @@
 </section>
 
 
+{{!--
 <section id="unique-totals" class="mb4">
   <h1 class="h2 mt0">Total vs. Unique Declarations</h1>
   <div class="flex flex-wrap mb4">
@@ -232,3 +233,4 @@
     </p>
   {{/if}}
 </section>
+--}}

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -184,14 +184,13 @@
   </p>
 </section>
 
-{{!--
 <section id="media-queries" class="mb4">
   <h1 class="h2 m0">
-    {{number stats.aggregates.mediaQueries.length }}
-    {{pluralize stats.aggregates.mediaQueries.length 'Media Query' 'Media Queries' }}
+    {{number mediaQueries.length }}
+    {{pluralize mediaQueries.length 'Media Query' 'Media Queries' }}
   </h1>
   <div class="flex flex-wrap mxn2">
-    {{#each stats.aggregates.mediaQueries }}
+    {{#each mediaQueries }}
       <div class="h5 bold break-word col-6 sm-col-4 px2 mb2">
         {{ this }}
       </div>
@@ -233,4 +232,3 @@
     </p>
   {{/if}}
 </section>
---}}

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -136,7 +136,6 @@
 </section>
 
 
-{{!--
 <section id="unique-totals" class="mb4">
   <h1 class="h2 mt0">Total vs. Unique Declarations</h1>
   <div class="flex flex-wrap mb4">
@@ -167,6 +166,7 @@
   </div>
 </section>
 
+{{!--
 <section id="specificity-graph" class="mb4">
   <h1 class="h2 mt0">Specificity Graph</h1>
   {{line_graph specificityGraph 1152 320 }}

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -166,7 +166,6 @@
   </div>
 </section>
 
-{{!--
 <section id="specificity-graph" class="mb4">
   <h1 class="h2 mt0">Specificity Graph</h1>
   {{line_graph specificityGraph 1152 320 }}
@@ -185,6 +184,7 @@
   </p>
 </section>
 
+{{!--
 <section id="media-queries" class="mb4">
   <h1 class="h2 m0">
     {{number stats.aggregates.mediaQueries.length }}

--- a/views/stats.handlebars
+++ b/views/stats.handlebars
@@ -116,8 +116,8 @@
   </h2>
   <div class="">
     {{#each uniques.fontSizeSorted }}
-      <div class="bold truncate mb1" style="font-size:{{ this.value }}">
-        Font Size {{ this.value }}
+      <div class="bold truncate mb1" style="font-size:{{ this }}">
+        Font Size {{ this }}
       </div>
     {{/each}}
   </div>
@@ -129,8 +129,8 @@
     {{pluralize uniques.fontFamily.length 'Unique Font Family' 'Unique Font Families' }}
   </h2>
   {{#each uniques.fontFamily }}
-    <div class="h3 bold break-word mb1" style="font-family:{{ this.value }}">
-      {{ this.value }}
+    <div class="h3 bold break-word mb1" style="font-family:{{ this }}">
+      {{ this }}
     </div>
   {{/each}}
 </section>


### PR DESCRIPTION
This addresses #175 and upgrades cssstats-core to 2.2.0. 

Let me know if fixes or style changes need to be made. I'll squash in the end to clean up the history if that's your contribution style. From spot testing multiple sites seems to returns the same results as the site in production.

This also allows us to use the awesome new features of 2.x. I also have code that builds on this which addresses counting margin/padding 0s (#146, #147) and unique z-indices (#163). I'll rebase and open PRs on these once this upgrade is finished.

#146, #147: https://github.com/cssstats/cssstats/compare/master...kevinwuhoo:count-spacing-0 
#163: https://github.com/cssstats/cssstats/compare/master...kevinwuhoo:count-z-index 