### PR TITLE
Fix bug integrating with new cssstats-core version

### DIFF
--- a/controllers/stats.js
+++ b/controllers/stats.js
@@ -14,7 +14,8 @@ function parseTotals(stats) {
   var totals = {};
   var totalProperties = ['float', 'width', 'height', 'color', 'background-color'];
   for(var property of totalProperties) {
-    totals[camelCase(property)] = stats.declarations.properties[property].length;
+    var prop = stats.declarations.properties[property];
+    totals[camelCase(property)] = prop ? prop.length : 0;
   }
 
   totals.fontSize = stats.declarations.getAllFontSizes().length;


### PR DESCRIPTION
After the latest cssstats version, CSS properties
are only added to the stats when they exist in the
stylesheet which cause the total parsing to :bomb:.