### PR TITLE
Add GitLab link

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -20,6 +20,7 @@ module.exports = function(obj) {
     { name: 'Wikipedia', url: 'http://www.wikipedia.org' },
     { name: 'Craigslist', url: 'http://newyork.craigslist.org' },
     { name: 'GitHub', url: 'http://github.com' },
+    { name: 'GitLab', url: 'https://gitlab.com/explore' },
     { name: 'Stack Overflow', url: 'http://stackoverflow.com' },
     { name: 'New York Times', url: 'http://nytimes.com' },
     { name: 'The Guardian', url: 'http://theguardian.com' },


### PR DESCRIPTION
Since https://gitlab.com redirects to https://about.gitlab.com when unauthenticated, I opted to use the https://gitlab.com/explore URL instead