### PR TITLE
Don't count @keyframes stops as selectors

### DIFF
--- a/packages/cssstats/lib/selectors.js
+++ b/packages/cssstats/lib/selectors.js
@@ -31,6 +31,10 @@ module.exports = function (root, opts) {
   var graph
 
   root.walkRules(function (rule) {
+    var parent = rule.parent
+    if (parent.type === 'atrule' && parent.name === 'keyframes') {
+      return
+    }
     rule.selectors.forEach(function (selector) {
       result.total++
       result.values.push(selector)

--- a/packages/cssstats/test/fixtures/keyframes.css
+++ b/packages/cssstats/test/fixtures/keyframes.css
@@ -8,6 +8,15 @@
   30% { color: blue; }
 }
 
+@keyframes grow {
+  from {
+    transform: scale(0.5);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
 .b {
   color: green;
   background-color: gray;

--- a/packages/cssstats/test/test.js
+++ b/packages/cssstats/test/test.js
@@ -138,6 +138,10 @@ describe('css-statistics', function () {
     it('should correctly get statistics for CSS in, and after, a keyframe', function () {
       assert.equal(keyframeStats.declarations.properties.color.length, 5)
     })
+
+    it('should not include @keyframes stops in the selectors list', function () {
+      assert.deepEqual(keyframeStats.selectors.values, ['.a', '.b'])
+    })
   })
 
   describe('selector methods', function () {


### PR DESCRIPTION
This fixes #259. I can't run the entire test suite successfully (see #258), though, so I don't know for sure whether this introduces any other bugs.