### PR TITLE
Fix underline on docs logo

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -87,7 +87,8 @@ export default {
       "fontWeight": "bold",
       "p": [1, 2, 3],
       "& a": {
-        "color": "black"
+        "color": "black",
+        "textDecoration": "none"
       }
     }
   }


### PR DESCRIPTION
Tiny detail—on the docs page, there's `text-decoration` on top of the logo:
<img width="215" alt="Screen Shot 2019-07-26 at 3 00 02 AM" src="https://user-images.githubusercontent.com/5074763/61936176-c98a3300-af51-11e9-9ee1-d5c61ebbd0f1.png">

This PR fixes it.