### PR TITLE
Improve URL inputs on mobile

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -69,7 +69,12 @@ export default ({ title, initialUrl, onUrlChange, children }) => {
                     }}
                   >
                   <Label display="none">Url</Label>
-                  <Input placeholder="Url to extract CSS stats" value={url} onChange={e => setUrl(e.target.value)} />
+                  <Input
+                    placeholder="Url to extract CSS stats"
+                    inputMode="url"
+                    value={url}
+                    onChange={e => setUrl(e.target.value)}
+                  />
                 </form>
               </div>
             ) : null}

--- a/src/components/UrlForm.js
+++ b/src/components/UrlForm.js
@@ -15,8 +15,15 @@ export default ({ showLabel = false }) => {
         navigate(`/stats?url=${url}`)
       }}
     >
-      <Label sx={{ mb: 2, display: showLabel ? 'block' : 'none' }}>Input a URL</Label>
-      <Input placeholder="google.com" value={url} onChange={e => setUrl(e.target.value)} />
+      <Label sx={{ mb: 2, display: showLabel ? 'block' : 'none' }}>
+        Input a URL
+      </Label>
+      <Input
+        placeholder="google.com"
+        inputMode="url"
+        value={url}
+        onChange={e => setUrl(e.target.value)}
+      />
     </form>
   )
 }

--- a/src/components/library/Input.js
+++ b/src/components/library/Input.js
@@ -15,7 +15,8 @@ const Input = styled('input')(
     boxSizing: 'border-box',
     fontFamily: 'inherit',
     fontSize: 'inherit',
-    borderRadius: '4px'
+    borderRadius: '4px',
+    WebkitAppearance: 'none'
   }),
   space,
   fontSize,

--- a/src/components/library/Input.js
+++ b/src/components/library/Input.js
@@ -15,8 +15,7 @@ const Input = styled('input')(
     boxSizing: 'border-box',
     fontFamily: 'inherit',
     fontSize: 'inherit',
-    borderRadius: '4px',
-    WebkitAppearance: 'none'
+    borderRadius: '4px'
   }),
   space,
   fontSize,

--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -27,7 +27,7 @@ export const Input = ({ ...props }) => (
       py: 3,
       px: 4,
       overflow: 'visible',
-      WekitAppearance: 'none',
+      WebkitAppearance: 'none',
       borderStyle: 'solid',
       borderRadius: 4,
       borderWidth: 1,


### PR DESCRIPTION
- Use URL keyboard (see #263) :)
- Remove WebKit's shadow
![image](https://user-images.githubusercontent.com/5074763/61936856-2e925880-af53-11e9-812a-f762b86c3161.png)
