### PR TITLE
Fix input alignment on stats page

### DIFF
--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -25,7 +25,7 @@ export const Input = ({ ...props }) => (
       display: 'block',
       width: '100%',
       py: 3,
-      px: 4,
+      px: 24,
       overflow: 'visible',
       WekitAppearance: 'none',
       borderStyle: 'solid',


### PR DESCRIPTION
This is a super small detail that's annoying me on the current design—the contents of the input aren't aligned with the container on the page. Notice the placeholder:

Current:
<img width="1440" alt="Screen Shot 2019-07-26 at 4 47 38 AM" src="https://user-images.githubusercontent.com/5074763/61943285-b9c61b00-af60-11e9-8448-de01b64f03ee.png">

This PR:
<img width="1440" alt="Screen Shot 2019-07-26 at 4 48 09 AM" src="https://user-images.githubusercontent.com/5074763/61943243-a915a500-af60-11e9-8170-d044a1a89189.png">
