### PR TITLE
Attribute selector with pound sign is not an ID selector

### DIFF
--- a/packages/has-id-selector/index.js
+++ b/packages/has-id-selector/index.js
@@ -13,5 +13,5 @@ module.exports = function hasIdSelector(selector, selectorToCheck) {
     return matcher.test(selector)
   }
 
-  return /#/.test(selector)
+  return /(?![^[]*])#/.test(selector)
 }

--- a/packages/has-id-selector/test/test.js
+++ b/packages/has-id-selector/test/test.js
@@ -7,10 +7,18 @@ var idSelectors = [
   '#bar::after',
   '#bar:after',
   '[input="text"] #foo',
-  'ul > li + li #baz'
+  'ul > li + li #baz',
+  'element#baz'
 ]
 
-var otherSelectors = ['.foo', 'a', '[input="text"]', 'a:visisted', 'li + li']
+var otherSelectors = [
+  '.foo',
+  'a',
+  '[input="text"]',
+  'a:visisted',
+  'li + li',
+  '[href="#anchor"]'
+]
 
 describe('has-id-selector', function() {
   it('should return true if there is an id selector', function() {


### PR DESCRIPTION
Selectors like `[href="#link-to-anchor-on-page`]` are not ID selectors. This regex makes sure that that pound sign is not within square brackets.

Source for this regex and extra test case: https://github.com/projectwallace/css-analyzer/blob/master/src/analyzer/selectors/id.js