### PR TITLE
add input type="url"

### DIFF
--- a/src/components/UrlForm.js
+++ b/src/components/UrlForm.js
@@ -22,6 +22,7 @@ export default ({ showLabel = false }) => {
         placeholder="google.com"
         inputMode="url"
         value={url}
+        type="url"
         onChange={e => setUrl(e.target.value)}
         sx={{ color: 'text' }}
       />


### PR DESCRIPTION
`inputMode` has very little browser support (https://caniuse.com/#search=inputmode), but `type="url"` has really good support (https://caniuse.com/#search=type%3Durl). This adds both