### PR TITLE
Fix style content return empty in cheerio 1.0.0-rc.3

### DIFF
--- a/packages/get-css/index.js
+++ b/packages/get-css/index.js
@@ -64,12 +64,12 @@ module.exports = function(url, options, html) {
       if (isPresent(link)) {
         result.links.push(createLink(link, url))
       } else {
-        result.styles.push(stripHtmlComments($(this).text()))
+        result.styles.push(stripHtmlComments($(this).html()))
       }
     })
 
     $('style').each(function() {
-      result.styles.push(stripHtmlComments($(this).text()))
+      result.styles.push(stripHtmlComments($(this).html()))
     })
 
     status.total = result.links.length + result.styles.length


### PR DESCRIPTION
The function `.text()` using `cheerio 1.0.0-rc.3` return empty. 

Updated to `.html()` fixed the problem.