### PR TITLE
Show homepage on /stats if no URL provided

### DIFF
--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -7,6 +7,7 @@ import { Styled } from 'theme-ui'
 
 import { H2, Div, Pre, Flex, Loading, SubHeader } from '../components/library'
 
+import Homepage from './index.mdx'
 import Layout from '../components/Layout'
 
 import SummaryStats from '../components/SummaryStats'
@@ -51,6 +52,10 @@ export default () => {
 
     fetchStats()
   }, [url])
+
+  if (!url && !stats) {
+    return <Homepage />
+  }
 
   if (!stats) {
     return (


### PR DESCRIPTION
Closes #295. If no URL has been entered or provided as a query param, CSS Stats will render the homepage (form + description) instead of showing (false) infinite loading.