### PR TITLE
Add button to copy CSS to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@mdx-js/react": "^2.0.0-next.8",
     "@sindresorhus/slugify": "^1.1.0",
     "ava": "^3.13.0",
+    "copy-to-clipboard": "^3.3.1",
     "gatsby": "^2.25.1",
     "gatsby-plugin-fathom": "^1.3.0",
     "gatsby-plugin-mdx": "^1.3.0",

--- a/src/components/ui.js
+++ b/src/components/ui.js
@@ -7,6 +7,7 @@ export const Link = ({ href, ...props }) => (
 )
 
 export const Label = ({ display = 'block', ...props }) => (
+  // eslint-disable-next-line jsx-a11y/label-has-associated-control
   <label
     sx={{
       display,
@@ -19,6 +20,7 @@ export const Label = ({ display = 'block', ...props }) => (
 )
 
 export const Input = ({ ...props }) => (
+  // eslint-disable-next-line jsx-a11y/control-has-associated-label
   <input
     sx={{
       fontSize: 2,

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -3,9 +3,12 @@ import { jsx } from 'theme-ui'
 import { useEffect, useState } from 'react'
 import getQueryParam from 'get-query-param'
 import isUrl from 'is-url'
-import { Styled } from 'theme-ui'
+import { Styled, IconButton } from 'theme-ui'
 
 import { H2, Div, Pre, Flex, Loading, SubHeader } from '../components/library'
+
+import { CheckSquare, Clipboard } from 'react-feather'
+import copy from 'copy-to-clipboard'
 
 import Layout from '../components/Layout'
 
@@ -31,6 +34,7 @@ const API_URL = 'https://cssstats.com/api'
 export default () => {
   const [stats, setStats] = useState(null)
   const [url, setUrl] = useState(null)
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     const linkFromQuery = getQueryParam('link', window.location.href)
@@ -375,6 +379,19 @@ export default () => {
       <DeclarationsChartSpacingMargin data={declarations} />
 
       <Div mt={5}>
+        <IconButton
+          role="button"
+          title="Copy CSS to clipboard"
+          sx={{ float: 'right' }}
+          tabindex="0"
+          onClick={() => {
+            setCopied(true)
+            copy(css.trim())
+            setTimeout(() => setCopied(false), 2000)
+          }}
+        >
+          {copied ? <CheckSquare /> : <Clipboard />}
+        </IconButton>
         <H2>Raw Css</H2>
         <Pre>{css.trim()}</Pre>
       </Div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5326,6 +5326,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 copyfiles@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.0.tgz#fcac72a4f2b882f021dd156b4bcf6d71315487bd"
@@ -16262,6 +16269,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I've sometimes wanted this feature for looking at CSS on a site, especially from my phone.

New button for copying:
![Screen Shot 2020-11-24 at 1 00 50 AM](https://user-images.githubusercontent.com/5074763/100054684-89aab880-2df0-11eb-8f19-d67cd8622381.png)

After you copy, switches to checkmark for 2.5 seconds:
![Screen Shot 2020-11-24 at 1 00 52 AM](https://user-images.githubusercontent.com/5074763/100054686-8adbe580-2df0-11eb-937b-f012b5377082.png)

Also suppressing two a11y warnings that aren't relevant to the codebase.