### PR TITLE
[get-css] Remove dependency on request

### DIFF
--- a/packages/get-css/package.json
+++ b/packages/get-css/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "format": "prettier --no-semi --single-quote --write {test,utils,bin}/**/*.js index.js",
-    "test": "node test/test && mocha test 'test/**/*.js'"
+    "test": "ava 'test/**/*.js'"
   },
   "bin": {
     "getcss": "./bin/getcss"
@@ -13,24 +13,24 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "cheerio": "^0.22.0",
     "commander": "^6.2.0",
     "is-blank": "^2.1.0",
     "is-css": "^3.5.0",
     "is-present": "^1.0.0",
     "is-url-superb": "^4.0.0",
+    "node-fetch": "^2.6.1",
     "normalize-url": "^5.3.0",
     "q": "^1.5.1",
     "query-string": "^6.13.6",
-    "request": "^2.88.2",
-    "requestretry": "^4.1.1",
     "resolve-css-import-urls": "^3.5.0",
     "strip-html-comments": "1.0.0",
     "strip-wayback-toolbar": "^1.0.4",
     "ua-string": "^3.1.0"
   },
   "devDependencies": {
-    "mocha": "^8.2.1",
+    "ava": "^3.14.0",
     "prettier": "^2.1.2"
   },
   "repository": {

--- a/packages/get-css/utils/create-link.js
+++ b/packages/get-css/utils/create-link.js
@@ -4,6 +4,6 @@ module.exports = function createLink(link, url) {
   return {
     link: link,
     url: resolveUrl(url, link),
-    css: ''
+    css: '',
   }
 }


### PR DESCRIPTION
We started using get-css to extract css from a user input website.

Upon deploying we figured out that request is required in our source to make it work because of a missing dependency in requestretry. Upon further investigation it turned out that this library was depending on requestretry, but not actually using the features from it, so I figured to remove that.

However, request itself is deprecated and should perhaps be replaced, for that purpose this also switched to node-fetch instead.

Small note: this (might) change the minimum version required by get-css. [Request supports Node >=6](https://github.com/request/request/blob/master/package.json#L21), [Node-fetch support ^10.17 || >=12.3](https://github.com/node-fetch/node-fetch/blob/master/package.json#L23), this support can be brought down by adding a globalThis polyfill [as described here](https://github.com/node-fetch/node-fetch#loading-and-configuring-the-module).

I hope this PR is appreciated even though it might not be asked for. ;)