### PR TITLE
Check content-type header instead of checking the URL to figure out if URL is actually serving CSS

### DIFF
--- a/packages/get-css/utils/get-link-contents.js
+++ b/packages/get-css/utils/get-link-contents.js
@@ -19,9 +19,11 @@ module.exports = function getLinkContents(linkUrl, options) {
       }
 
       var contentType = response.headers.get('content-type')
+      // Has contentType header and is text/css
       var hasCssContentType = contentType && contentType.includes('text/css')
+      // Has no contentType header and end with .css
       var urlHasCssExtension = !contentType && /\.css$/i.test(url)
-      console.log(hasCssContentType, urlHasCssExtension)
+      // If neither is the case ignore this link, consider there to be no css
       if (!hasCssContentType && !urlHasCssExtension) {
         d.resolve('')
       }

--- a/packages/get-css/utils/get-link-contents.js
+++ b/packages/get-css/utils/get-link-contents.js
@@ -7,13 +7,6 @@ module.exports = function getLinkContents(linkUrl, options) {
   var d = q.defer()
   const { url } = query.parseUrl(linkUrl)
 
-  // expect linked css content
-  // TODO: Make this check the actual response type
-  if (!/\.css$/i.test(url)) {
-    d.resolve('')
-    return d.promise
-  }
-
   var controller = new AbortController()
   var timeoutTimer = setTimeout(() => {
     controller.abort()
@@ -23,6 +16,14 @@ module.exports = function getLinkContents(linkUrl, options) {
     .then((response) => {
       if (response.status !== 200) {
         d.reject(response.error)
+      }
+
+      var contentType = response.headers.get('content-type')
+      var hasCssContentType = contentType && contentType.includes('text/css')
+      var urlHasCssExtension = !contentType && /\.css$/i.test(url)
+      console.log(hasCssContentType, urlHasCssExtension)
+      if (!hasCssContentType && !urlHasCssExtension) {
+        d.resolve('')
       }
 
       return response.text()


### PR DESCRIPTION
This will use the content-type header instead of the url extension to figure out which URL's are css.

If no content type header is present, it will fallback to checking the extension as before.

I tested this locally (outside of cssStats) with an API I'm building.