### PR TITLE
Resolve issues with importing css files

### DIFF
--- a/packages/get-css/index.js
+++ b/packages/get-css/index.js
@@ -18,7 +18,7 @@ var createLink = require('./utils/create-link')
 module.exports = function (url, options, html) {
   var deferred = q.defer()
   options = options || {}
-  var timeout = options.timeout || 5000
+  options.timeout = options.timeout || 5000
 
   if (typeof url !== 'string' || isBlank(url) || !isUrl(url)) {
     throw new TypeError('get-css expected a url as a string')
@@ -75,7 +75,7 @@ module.exports = function (url, options, html) {
     }
 
     result.links.forEach(function (link) {
-      getLinkContents(link.url, options, { timeout })
+      getLinkContents(link.url, options)
         .then(function (css) {
           handleCssFromLink(link, css)
         })
@@ -139,14 +139,14 @@ module.exports = function (url, options, html) {
   } else {
     var controller = new AbortController()
 
-    var options = options || {}
+    var options = Object.assign({}, options)
     options.headers = options.headers || {}
     options.headers['User-Agent'] = options.headers['User-Agent'] || ua
     options.signal = controller.signal
 
     var timeoutTimer = setTimeout(() => {
       controller.abort()
-    }, timeout)
+    }, options.timeout)
     fetch(url, options)
       .then((response) => {
         if (response && response.status != 200) {

--- a/packages/get-css/utils/get-link-contents.js
+++ b/packages/get-css/utils/get-link-contents.js
@@ -3,7 +3,7 @@ var fetch = require('node-fetch')
 var query = require('query-string')
 var AbortController = require('abort-controller')
 
-module.exports = function getLinkContents(linkUrl, linkOptions, options) {
+module.exports = function getLinkContents(linkUrl, options) {
   var d = q.defer()
   const { url } = query.parseUrl(linkUrl)
 
@@ -12,9 +12,7 @@ module.exports = function getLinkContents(linkUrl, linkOptions, options) {
     controller.abort()
   }, options.timeout)
 
-  linkOptions.signal = controller.signal
-
-  fetch(linkUrl, linkOptions)
+  fetch(linkUrl, Object.assign({}, options, { signal: controller.signal }))
     .then((response) => {
       if (response.status !== 200) {
         d.reject(response.error)


### PR DESCRIPTION
So today I figured out that I have made a mistake before. This means that currently any website that uses @import statements will not work.

This is caused by not properly passing an object to the `getLinkContents` when looping through the imports. To resolve this I simplify timeout management.

This also ensure that objects are not overwriting each other but instead duplicate the object before adding/updating a key.

Example sites that use @import statement in their css:
https://giosg.com
https://demo.giosg.com

I'm sorry for the trouble I hope this PR makes up for my mistake. ;)