### PR TITLE
Remove process.exit(0) from read file call

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -27,5 +27,4 @@ read(inputFile, (err, buffer) => {
   }
 
   write(outputFile, JSON.stringify(cssstats(String(buffer))))
-  process.exit(0)
 })


### PR DESCRIPTION
I've been hitting this problem where I'm trying to get the output of cssstats piped to another process. However because the file I'm processing is so large the output buffer I'm getting is getting cut off because the process is exiting before the stream has completed.

**A simple example**

When running this bash script I'm trying to store the output in a variable.  input file https://gist.github.com/jonrohan/dbb59da4602c2e4a0ebfdcf28a592451

```bash
output=$(cssstats behaviors.css);echo $output
```

The tail end of the the JSON output of that command ends in `".table-list-`

```json
.collapsible-sidebar-widget-indicator","declarations":2},{"selector":".collapsible-sidebar-widget-indicator","declarations":2},{"selector":".capped-card-content::before","declarations":2},{"selector":".capped-card-content","declarations":2},{"selector":".breadcrumb","declarations":2},{"selector":".table-list-header-next .select-all-dropdown","declarations":2},{"selector":".table-list-header-next","declarations":2},{"selector":".table-list-
```

I found that removing the process.exit here will give me the full results.